### PR TITLE
Fix sorting by removing the 'Kb' from the column

### DIFF
--- a/src/class-admin-page.php
+++ b/src/class-admin-page.php
@@ -207,7 +207,7 @@ class Admin_Page {
 			echo '<thead>';
 			echo '<tr>';
 			echo '<th>' . esc_html__( 'Option', 'aaa-option-optimizer' ) . '</th>';
-			echo '<th>' . esc_html__( 'Size', 'aaa-option-optimizer' ) . '</th>';
+			echo '<th>' . esc_html__( 'Size (Kb)', 'aaa-option-optimizer' ) . '</th>';
 			echo '<th>' . esc_html__( 'Value', 'aaa-option-optimizer' ) . '</th>';
 			echo '<th>' . esc_html__( 'Actions', 'aaa-option-optimizer' ) . '</th>';
 			echo '</tr>';
@@ -215,7 +215,7 @@ class Admin_Page {
 			echo '<tbody>';
 			foreach ( $unused_options as $option => $value ) {
 				echo '<tr id="option_' . esc_attr( str_replace( ':', '', str_replace( '.', '', $option ) ) ) . '"><td>' . esc_html( $option ) . '</td>';
-				echo '<td>' . esc_html( $this->get_length( $value ) ) . 'KB</td>';
+				echo '<td>' . esc_html( $this->get_length( $value ) ) . '</td>';
 				echo '<td class="value">';
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- output escaped in get_popover_html.
 				echo $this->get_popover_html( $option, $value );
@@ -237,7 +237,7 @@ class Admin_Page {
 			echo '<thead>';
 			echo '<tr>';
 			echo '<th>' . esc_html__( 'Option', 'aaa-option-optimizer' ) . '</th>';
-			echo '<th>' . esc_html__( 'Size', 'aaa-option-optimizer' ) . '</th>';
+			echo '<th>' . esc_html__( 'Size (Kb)', 'aaa-option-optimizer' ) . '</th>';
 			echo '<th>' . esc_html__( 'Value', 'aaa-option-optimizer' ) . '</th>';
 			echo '<th>' . esc_html__( '# Calls', 'aaa-option-optimizer' ) . '</th>';
 			echo '<th>' . esc_html__( 'Actions', 'aaa-option-optimizer' ) . '</th>';
@@ -247,7 +247,7 @@ class Admin_Page {
 			foreach ( $non_autoloaded_options_full as $option => $arr ) {
 				echo '<tr id="option_' . esc_attr( str_replace( ':', '', str_replace( '.', '', $option ) ) ) . '">';
 				echo '<td>' . esc_html( $option ) . '</td>';
-				echo '<td>' . esc_html( $this->get_length( $arr['value'] ) ) . 'KB</td>';
+				echo '<td>' . esc_html( $this->get_length( $arr['value'] ) ) . '</td>';
 				echo '<td class="value">';
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- output escaped in get_popover_html.
 				echo $this->get_popover_html( $option, $arr['value'] );


### PR DESCRIPTION
DataTables can't correctly sort the columns because they're not numbers, and that is caused by the 'Kb' in the column. My suggestion would be to simply move the Kb to the header instead, which makes this the simples fix I can think of for this issue.

## Context
Currently, the sorting doesn't work as expected because the column doesn't contain just numbers, but is a string due to the 'kb' addition. Moving the KB to the header fixes that. 

*

## Summary

This PR can be summarized in the following changelog entry:
Fix sorting of size column

*

## Relevant technical choices:

* used the simples approach by letting the Datatables library handle the sorting by making it an actual 'number' type. 

## Test instructions
- Current version does not sort correctly, e.g. 4.5 can be seen as larger than 43, as it is handled as a string. 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [v ] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] I have checked that the base branch is correctly set.

Fixes #
