### PR TITLE
added plugin prefixes

### DIFF
--- a/known-plugins/known-plugins.json
+++ b/known-plugins/known-plugins.json
@@ -3,6 +3,14 @@
         "name": "AAA Option Optimizer",
         "option_prefixes": ["option_optimizer"]
     },
+    "advanced-custom-fields": {
+        "name": "Advanced Custom Fields",
+        "option_prefixes": ["acf_"]
+    },
+    "affiliate-wp": {
+        "name": "Affiliate WP",
+        "option_prefixes": ["affwp_"]
+    },
     "burst": {
         "name": "Burst Statistics",
         "option_prefixes": ["burst_"]
@@ -10,6 +18,10 @@
     "complianz": {
         "name": "Complianz GDPR",
         "option_prefixes": ["cmplz_"]
+    },
+    "duplicate-post": {
+        "name": "Yoast Duplicate Post",
+        "option_prefixes": ["duplicate_post_"]
     },
     "easy-digital-downloads": {
         "name": "Easy Digital Downloads",
@@ -19,9 +31,21 @@
         "name": "Elementor",
         "option_prefixes": ["elementor_"]
     },
+    "google-analytics-for-wordpress": {
+        "name": "Google Analytics for WordPress by MonsterInsights",
+        "option_prefixes": ["yst_"]
+    },
+    "gravity-forms": {
+        "name": "Gravity Forms",
+        "option_prefixes": ["gf_"]
+    },
     "really-simple-ssl": {
         "name": "Really Simple SSL",
         "option_prefixes": ["rsssl_"]
+    },
+    "updraft": {
+        "name": "Updraft Plus",
+        "option_prefixes": ["updraft_"]
     },
 	"yoast": {
 		"name": "Yoast SEO",


### PR DESCRIPTION
## Context
Some more prefixes from plugins I came across when cleaning up options.

*

## Summary

This PR can be summarized in the following changelog entry:

* Added Yoast Duplicate Post, Updraft Plus, Google Analytics for WP, Affiliate WP, Advanced Custom Fields, Gravity Forms to the prefixes list

## Relevant technical choices:

* none

## Test instructions
A simple code review should do here

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [v ] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] I have checked that the base branch is correctly set.

Fixes #
