### PR TITLE
Add translation strings

### DIFF
--- a/js/admin-script.js
+++ b/js/admin-script.js
@@ -55,6 +55,8 @@ jQuery( document ).ready(
 				options.rowId = 'row_id';
 			}
 
+			options.language = aaaOptionOptimizer.i18n;
+
 			const dataTable = new DataTable( selector, options );
 		}
 

--- a/src/class-admin-page.php
+++ b/src/class-admin-page.php
@@ -128,6 +128,27 @@ class Admin_Page {
 					'addAutoload'    => esc_html__( 'Add autoload', 'aaa-option-optimizer' ),
 					'removeAutoload' => esc_html__( 'Remove autoload', 'aaa-option-optimizer' ),
 					'deleteOption'   => esc_html__( 'Delete option', 'aaa-option-optimizer' ),
+
+					'search'         => esc_html__( 'Search:', 'aaa-option-optimizer' ),
+					'entries'        => [
+						'_' => \esc_html__( 'entries', 'aaa-option-optimizer' ),
+						'1' => \esc_html__( 'entry', 'aaa-option-optimizer' ),
+					],
+					'sInfo'          => sprintf(
+						// translators: %1$s is the start, %2$s is the end, %3$s is the total, %4$s is the entries.
+						esc_html__( 'Showing %1$s to %2$s of %3$s %4$s', 'aaa-option-optimizer' ),
+						'_START_',
+						'_END_',
+						'_TOTAL_',
+						'_ENTRIES-TOTAL_'
+					),
+					'sInfoEmpty'      => esc_html__( 'Showing 0 to 0 of 0 entries', 'aaa-option-optimizer' ),
+					'sInfoFiltered'   => sprintf(
+						// translators: %1$s is the max, %2$s is the entries-max.
+						esc_html__( '(filtered from %1$s total %2$s)', 'aaa-option-optimizer' ),
+						'_MAX_',
+						'_ENTRIES-MAX_'
+					),
 				],
 			]
 		);

--- a/src/class-admin-page.php
+++ b/src/class-admin-page.php
@@ -149,6 +149,18 @@ class Admin_Page {
 						'_MAX_',
 						'_ENTRIES-MAX_'
 					),
+					'sZeroRecords'   => esc_html__( 'No matching records found', 'aaa-option-optimizer' ),
+					'oAria'          => [
+						'orderable'        => esc_html__( ': Activate to sort', 'aaa-option-optimizer' ),
+						'orderableReverse' => esc_html__( ': Activate to invert sorting', 'aaa-option-optimizer' ),
+						'orderableRemove'  => esc_html__( ': Activate to remove sorting', 'aaa-option-optimizer' ),
+						'paginate'         => [
+							'first'    => esc_html__( 'First', 'aaa-option-optimizer' ),
+							'last'     => esc_html__( 'Last', 'aaa-option-optimizer' ),
+							'next'     => esc_html__( 'Next', 'aaa-option-optimizer' ),
+							'previous' => esc_html__( 'Previous', 'aaa-option-optimizer' ),
+						],
+					],
 				],
 			]
 		);

--- a/src/class-admin-page.php
+++ b/src/class-admin-page.php
@@ -142,8 +142,8 @@ class Admin_Page {
 						'_TOTAL_',
 						'_ENTRIES-TOTAL_'
 					),
-					'sInfoEmpty'      => esc_html__( 'Showing 0 to 0 of 0 entries', 'aaa-option-optimizer' ),
-					'sInfoFiltered'   => sprintf(
+					'sInfoEmpty'     => esc_html__( 'Showing 0 to 0 of 0 entries', 'aaa-option-optimizer' ),
+					'sInfoFiltered'  => sprintf(
 						// translators: %1$s is the max, %2$s is the entries-max.
 						esc_html__( '(filtered from %1$s total %2$s)', 'aaa-option-optimizer' ),
 						'_MAX_',


### PR DESCRIPTION
## Summary

* Adds some missing translation strings

## Technical choices

Got the original strings from https://github.com/DataTables/DataTablesSrc/blob/ba5e121e7fc4bdae642179fe79e3c76de9a41619/js/model/model.defaults.js#L508-L712

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

Fixes #11 
