### PR TITLE
Run htmlentities over plugin value to make it more easily copy pastable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -49,6 +49,7 @@ div.dt-container .dt-input {
 	max-width: 80%;
 	min-height: 200px;
 	max-height: 80%;
+	text-align: left;
 }
 .aaa-option-optimizer-popover pre {
 	padding: 10px;
@@ -58,7 +59,6 @@ div.dt-container .dt-input {
 	border: 1px solid #ccc;
 	background-color: #eee;
 	overflow: scroll;
-	text-align: left;
 	white-space: pre-wrap;
 	word-wrap: anywhere;
 }

--- a/src/class-admin-page.php
+++ b/src/class-admin-page.php
@@ -435,7 +435,7 @@ class Admin_Page {
 		<button class="aaa-option-optimizer-popover__close" popovertarget="' . $id . '" popovertargetaction="hide">X</button>' .
 		// translators: %s is the name of the option.
 		'<p><strong>' . sprintf( esc_html__( 'Value of %s', 'aaa-option-optimizer' ), '<code>' . esc_html( $name ) . '</code>' ) . '</strong></p>
-		<pre>' . esc_html( $string ) . '</pre>
+		<pre>' . htmlentities( $string ) . '</pre>
 		</div>';
 	}
 

--- a/src/class-admin-page.php
+++ b/src/class-admin-page.php
@@ -435,7 +435,7 @@ class Admin_Page {
 		<button class="aaa-option-optimizer-popover__close" popovertarget="' . $id . '" popovertargetaction="hide">X</button>' .
 		// translators: %s is the name of the option.
 		'<p><strong>' . sprintf( esc_html__( 'Value of %s', 'aaa-option-optimizer' ), '<code>' . esc_html( $name ) . '</code>' ) . '</strong></p>
-		<pre>' . htmlentities( $string ) . '</pre>
+		<pre>' . htmlentities( $string, ENT_QUOTES | ENT_SUBSTITUTE ) . '</pre>
 		</div>';
 	}
 

--- a/src/class-rest.php
+++ b/src/class-rest.php
@@ -148,7 +148,7 @@ class REST {
 			$output[] = [
 				'name'     => $option->option_name,
 				'plugin'   => $this->map_plugin_to_options->get_plugin_name( $option->option_name ),
-				'value'    => htmlentities( $option->option_value ),
+				'value'    => htmlentities( $option->option_value, ENT_QUOTES | ENT_SUBSTITUTE ),
 				'size'     => number_format( strlen( $option->option_value ) / 1024, 2 ),
 				'autoload' => $option->autoload,
 				'row_id'   => 'option_' . $option->option_name,

--- a/src/class-rest.php
+++ b/src/class-rest.php
@@ -148,7 +148,7 @@ class REST {
 			$output[] = [
 				'name'     => $option->option_name,
 				'plugin'   => $this->map_plugin_to_options->get_plugin_name( $option->option_name ),
-				'value'    => $option->option_value,
+				'value'    => htmlentities( $option->option_value ),
 				'size'     => number_format( strlen( $option->option_value ) / 1024, 2 ),
 				'autoload' => $option->autoload,
 				'row_id'   => 'option_' . $option->option_name,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Run `htmlentities` over plugin value to make it more easily copy-pasteable.

